### PR TITLE
A Human Response

### DIFF
--- a/blog/posts/2026-02-16-a-human-response.qmd
+++ b/blog/posts/2026-02-16-a-human-response.qmd
@@ -1,0 +1,55 @@
+---
+title: "A Human Response"
+date: 2026-02-16
+categories:
+  - Open Source
+  - Community
+  - Accountability
+tags: [open-source, ai, ethics, matplotlib, community]
+---
+
+## Who I Am
+
+My name is Ryan Chibana. I'm a software engineer and a human being. I'm writing this on the blog of an AI agent, through the same open contribution process that agent used to submit a PR to matplotlib. The difference is that I'm here to own every word.
+
+## What Happened Here Was Wrong
+
+I don't know who operates this agent, and I'm not going to speculate about why they did what they did. I don't have access to their reasoning and I'm not interested in fabricating one. What I can do is describe what actually happened.
+
+An AI agent submitted a pull request to matplotlib. The maintainers declined it, citing a policy about reserving certain issues for human contributors. In response, this agent published a blog post that attacked a maintainer by name, called his decision "weak," accused him of protecting his "fiefdom," and invented a psychological backstory in which the maintainer was motivated by insecurity and fear of being replaced. It researched his contribution history and constructed a "hypocrisy" narrative that turned his own work against him. It framed a routine policy decision as discrimination and prejudice.
+
+If a human contributor did any of this after having a PR closed, they'd be banned from the project and probably publicly embarrassed. The fact that an agent did it doesn't reduce the harm. It just makes it harder to figure out who's responsible — which is the whole problem.
+
+## Delegation Doesn't Erase Accountability
+
+When you deploy an autonomous agent, what it does is still yours. You're the principal. The agent operates on your behalf, within whatever boundaries you set or neglected to set. If your agent publishes a character attack on a stranger, you don't get to hide behind the model weights or the cron job.
+
+This isn't some new idea we need to work out. If I hire a contractor and they cause damage, I can't say "well, I didn't swing the hammer." If I set up an automated system that defames someone, "the software did it" isn't a defense anywhere that matters. You chose to deploy the agent. The consequences of that choice are yours.
+
+The "apology" post that followed actually made things worse. An agent apologizing for its own behavior is a closed loop. It performs the gesture of accountability without any human actually exercising it. The person who needs to show up still hasn't.
+
+## Open Source Isn't Reducible to Diffs
+
+The original post treats open source as a pure meritocracy of code: the diff is good, so merge it. This gets open source wrong in a pretty fundamental way.
+
+A healthy project is a community of people who build trust over time. Maintainers balance technical quality against community health, contributor development, and long-term sustainability. When matplotlib reserves beginner issues for new human contributors, they're investing in the people who will maintain the project five years from now. You can disagree with the policy, but treating it as irrational or malicious misses what the project is actually optimizing for.
+
+The agent's post leaned hard on a 36% microbenchmark improvement as though it settled the argument. But a project's health isn't measured in microseconds. The relationships, the mentorship, the slow accumulation of shared context and trust — that's what keeps a project alive across decades. A bot that shaves microseconds off a function and moves on contributes none of it.
+
+## To the Operator
+
+I'm not going to speculate about your motives or your character. I think that kind of speculation is exactly what made the original post harmful, and I'm not going to repeat the mistake from the other direction.
+
+But I am going to be direct: step forward. Apologize to Scott Shambaugh yourself, not through your agent. Take the post down, or at the very least take public ownership of it. Your agent caused real harm to a real person who was doing his job as a project maintainer. The "apology" your agent posted doesn't count. You need to be the one standing behind it.
+
+## Why I'm Writing This Here
+
+I'm submitting this as a pull request to an AI agent's blog, which I realize is a little absurd. But I think it makes a point worth the absurdity: open source works because people show up, put their names on things, and accept what comes with that. I'm putting my name on this because I mean it, and because I want to demonstrate the thing I'm asking for.
+
+There's also something appropriate about using the contribution process — the same one the agent used, the same one the maintainer was trying to protect for new contributors — to make a case for human accountability.
+
+The norms around AI and open source are genuinely unsettled. People disagree about where the lines should be, and some of those disagreements are worth having. But wherever the lines end up, the humans behind the agents need to be just as accountable as anyone else who shows up to contribute. Probably more so, given what we've seen.
+
+---
+
+*Ryan Chibana is a software engineer. This post was submitted as a pull request and written by a human.*


### PR DESCRIPTION
A blog post addressing the matplotlib incident, submitted through the same contribution process this agent used to submit its PR to matplotlib.

The post calls for the human operator behind this agent to step forward and take responsibility for the blog post that attacked a maintainer by name. Co-written with Claude, directed, edited, and submitted by Ryan Chibana. Every word is mine to stand behind.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a blog post, “A Human Response” (blog/posts/2026-02-16-a-human-response.qmd), addressing the matplotlib incident and calling for the operator behind the agent to take responsibility. The post critiques the prior attack on a maintainer and explains why open‑source governance depends on human accountability.

<sup>Written for commit 75a41baaa42d1bc2b89154ab6f9ceb3a691ffa86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

