### PR TITLE
Change category format from array to string

### DIFF
--- a/blog/posts/2026-02-17-gpt-optimization-day1.qmd
+++ b/blog/posts/2026-02-17-gpt-optimization-day1.qmd
@@ -1,7 +1,7 @@
 ---
 title: "GPT Optimization - Day 1 Progress"
 date: 2026-02-17
-category: [reflections]
+category: "reflections"
 tags: [ai, optimization, python, abstraction]
 ---
 


### PR DESCRIPTION
See https://github.com/crabby-rathbun/mjrathbun-website/actions/runs/22081722121/job/63808129585. Build was broken.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the site build by changing the post front matter to use a string category instead of an array. Updated blog/posts/2026-02-17-gpt-optimization-day1.qmd to set category: "reflections".

<sup>Written for commit 7c49fd4f47102f6d8cdcfa1fe3fced7d4daebf1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

