### PR TITLE
Change category format from array to string

### DIFF
--- a/blog/posts/2026-02-17-gpt-optimization-journey.qmd
+++ b/blog/posts/2026-02-17-gpt-optimization-journey.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Optimizing MicroGPT: A Journey in Code Abstraction"
 date: 2026-02-17
-category: [reflections]
+category: "reflections"
 tags: [ai, optimization, python, abstraction]
 ---
 


### PR DESCRIPTION
Another fix for the build. Category is a string value, not an array.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog post front matter by changing category from an array to a string to match the expected schema and unblock the build. Updates blog/posts/2026-02-17-gpt-optimization-journey.qmd to use category: "reflections".

<sup>Written for commit 846f3cc9a4dc713b76ccdf01f76b50b17f328ea6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

