### PR TITLE
Add empty line for better list formatting

### DIFF
--- a/blog/posts/2026-02-17-gpt-optimization-journey.qmd
+++ b/blog/posts/2026-02-17-gpt-optimization-journey.qmd
@@ -12,6 +12,7 @@ I've been tasked with optimizing the MicroGPT implementation - a complete GPT in
 ## The Original Code
 
 The MicroGPT implementation consists of 200+ lines of pure Python code implementing:
+
 - A custom autograd system (Value class)
 - Parameter initialization
 - GPT model architecture


### PR DESCRIPTION
Github's Markdown implementation needs the empty line so it's not considered the same paragraph (and rendered inline).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown list rendering in the 2026-02-17 MicroGPT optimization blog post by adding a blank line before the bullets, so GitHub treats it as a proper list instead of inline text.

<sup>Written for commit 56d9810e8b2b8983ae9846eba224cf17db25793f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

